### PR TITLE
Weather Fix for bad API data

### DIFF
--- a/scripts/parks/ParkPreviewHTMLgenerator.js
+++ b/scripts/parks/ParkPreviewHTMLgenerator.js
@@ -4,7 +4,6 @@ const eventHub = document.querySelector('.container');
 export const ParkPreviewHTMLgenerator = (park) => {
   let weather = [];
   let parkPreviewHTML;
-
   weather = useWeather();
 
   const weatherFunction = () => {
@@ -21,7 +20,6 @@ export const ParkPreviewHTMLgenerator = (park) => {
       let humanDate = dateObject.toLocaleDateString('en-us', dateOptions);
       let low = date.temp.min;
       let high = date.temp.max;
-      let desc = date.weather[0].description;
       let img = date.weather[0].icon;
 
       return `<div class="weather-card">
@@ -38,6 +36,14 @@ export const ParkPreviewHTMLgenerator = (park) => {
     return weatherOutputArray.join('');
   };
 
+  const weatherDisplay = (lat, long) => {
+    if (lat && long !== '') {
+      return weatherFunction();
+    } else {
+      return 'No Weather Information Available';
+    }
+  };
+
   parkPreviewHTML = `
     <div class="preview-card preview-card--park">
       <div class="preview-card--park__info">
@@ -46,11 +52,13 @@ export const ParkPreviewHTMLgenerator = (park) => {
           <h4>
             ${park.fullName}
           </h4>
-          <p class="bold">${park.addresses[0].city}, ${park.addresses[0].stateCode}</p>
+          <p class="bold">${park.addresses[0].city}, ${
+    park.addresses[0].stateCode
+  }</p>
         </div>
       </div>
       <div class="park-weather">
-        ${weatherFunction()}
+        ${weatherDisplay(park.latitude, park.longitude)}
       </div>
       <div class="detailButton">
         <button class="parkDetails" id="parkDetailButton--${

--- a/scripts/parks/ParkPreviewList.js
+++ b/scripts/parks/ParkPreviewList.js
@@ -13,13 +13,17 @@ eventHub.addEventListener('parkChosen', (event) => {
       (park) => park.id === event.detail.parkThatWasChosen
     );
 
-    getWeather(chosenPark.latitude, chosenPark.longitude).then(() => {
+    if (chosenPark.latitude && chosenPark.longitude !== '') {
+      getWeather(chosenPark.latitude, chosenPark.longitude).then(() => {
+        parkPreviewTarget.innerHTML = ParkPreviewHTMLgenerator(chosenPark);
+      });
+    } else {
       parkPreviewTarget.innerHTML = ParkPreviewHTMLgenerator(chosenPark);
-    });
+    }
   } else parkPreviewTarget.innerHTML = '';
 });
 
-eventHub.addEventListener('click', (clickEvent)=> {
+eventHub.addEventListener('click', (clickEvent) => {
   if (!clickEvent.target.id.startsWith('parkDetailButton--')) {
     return;
   }
@@ -27,8 +31,8 @@ eventHub.addEventListener('click', (clickEvent)=> {
 
   const customEvent = new CustomEvent('parkDetailClicked', {
     detail: {
-      parkId: parkId
-    }
-  })
+      parkId: parkId,
+    },
+  });
   eventHub.dispatchEvent(customEvent);
-})
+});


### PR DESCRIPTION
## changes
- refactored weather code to include a check for latitude and longitude to avert issue where parks with missing lat/long would break app
## testing
- fetch and serve page
- select a national park from the list that doesn't have lat/long info (i.e. Ala Kahakai National Historic Trail)
- make sure "No Weather Information Available" appears in lieu of 5-day forecast
- select a non-broken park to make sure the weather still appears