### PR TITLE
dialog positioning

### DIFF
--- a/scripts/parks/ParkDetailHTMLgenerator.js
+++ b/scripts/parks/ParkDetailHTMLgenerator.js
@@ -8,6 +8,9 @@ export const ParkDetailsHTMLgenerator = (park) => {
 
   return `
   <div class="park-details">
+  <div class="park-details__closeButtonContainer">
+  <button id="closeModal">Close</button>
+  </div>
     <h2>${park.fullName}</h2>
     <p class="park-details__location bold">${park.addresses[0].city}, ${park.addresses[0].stateCode}</p>
     <p class="park-details__description">${park.description}</p>
@@ -32,9 +35,6 @@ export const ParkDetailsHTMLgenerator = (park) => {
       <img src="${park.images[imageNumber].url}" alt="${park.images[imageNumber].altText}">
     </div>
     </div>
-    </div>
-    <div class="park-details__closeButtonContainer">
-    <button id="closeModal">Close</button>
     </div>
   </div>
   `

--- a/scripts/parks/ParkDetailHTMLgenerator.js
+++ b/scripts/parks/ParkDetailHTMLgenerator.js
@@ -14,7 +14,7 @@ export const ParkDetailsHTMLgenerator = (park) => {
     <div class="park-details__subcontainer">
     <div class="park-details__activities">
     <h4>Activities: </h4>
-    <div>
+    <div class="park-details__activitiesList">
       ${park.activities.map((activity)=>{
         return `<p>${activity.name}</p>`
       }).join('')}

--- a/styles/itineraries.css
+++ b/styles/itineraries.css
@@ -1,6 +1,6 @@
 aside {
   background-color:  var(--secondary-bg-color);
-  height: 100vh;
+  height: 95vh;
   border-left: 3px solid rgb(109, 94, 30);
   padding: 1em;
   margin-left: 2em;

--- a/styles/park.css
+++ b/styles/park.css
@@ -42,6 +42,8 @@
   width: 70%;
   position: fixed;
   top: 10%;
+  max-height: 95vh;
+  overflow-y: scroll;
 }
 
 .park-details h2 {
@@ -67,8 +69,8 @@
 .park-details__activitiesList {
   display: flex;
   flex-direction: column;
-  flex-wrap: wrap;
-  max-height: 30em;
+  /* flex-wrap: wrap; */
+  /* max-height: 30em; */
 }
 
 .park-details__contact {

--- a/styles/park.css
+++ b/styles/park.css
@@ -40,6 +40,8 @@
 
 .park-dialog {
   width: 70%;
+  position: fixed;
+  top: 10%;
 }
 
 .park-details h2 {
@@ -80,6 +82,6 @@
 }
 
 .park-details__image img {
-  max-width: 300px;
+  max-width: 500px;
   border-radius: 1em;
 }

--- a/styles/park.css
+++ b/styles/park.css
@@ -64,6 +64,13 @@
   justify-content: space-evenly;  
 }
 
+.park-details__activitiesList {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  max-height: 30em;
+}
+
 .park-details__contact {
   margin-bottom: 2em;
   text-align: center;

--- a/styles/park.css
+++ b/styles/park.css
@@ -41,9 +41,9 @@
 .park-dialog {
   width: 70%;
   position: fixed;
-  top: 10%;
-  max-height: 95vh;
-  overflow-y: scroll;
+  top: 5%;
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 .park-details h2 {
@@ -87,7 +87,7 @@
 
 .park-details__closeButtonContainer {
   display: flex;
-  justify-content: center;
+  justify-content: flex-end;
 }
 
 .park-details__image img {


### PR DESCRIPTION
## changes:
- positioned park dialog box to stay high on the screen
- added scroll behavior for parks with long activity lists
- moved close button to avoid needing to scroll to click it
## testing
- fetch and serve
- select a park with a lot of activities (Glacier National Park), click details button
- observe scroll behavior in dialog box
- select a park without a long activity list
- no scroll bar should be visible in the dialog box