### PR TITLE
Fixed 'undefined' issue in parks

### DIFF
--- a/scripts/parks/ParkPreviewHTMLgenerator.js
+++ b/scripts/parks/ParkPreviewHTMLgenerator.js
@@ -44,28 +44,53 @@ export const ParkPreviewHTMLgenerator = (park) => {
     }
   };
 
-  parkPreviewHTML = `
-    <div class="preview-card preview-card--park">
-      <div class="preview-card--park__info">
-        <input type="hidden" id="selectedPark" value="${park.id}">
-        <div class="park-info__nameAndLocation">
-          <h4>
-            ${park.fullName}
-          </h4>
-          <p class="bold">${park.addresses[0].city}, ${
-    park.addresses[0].stateCode
-  }</p>
+  if (park.addresses.length > 0) {
+    parkPreviewHTML = `
+      <div class="preview-card preview-card--park">
+        <div class="preview-card--park__info">
+          <input type="hidden" id="selectedPark" value="${park.id}">
+          <div class="park-info__nameAndLocation">
+            <h4>
+              ${park.fullName}
+            </h4>
+            <p class="bold">${park.addresses[0].city}, ${
+      park.addresses[0].stateCode
+    }</p>
+          </div>
+        </div>
+        <div class="park-weather">
+          ${weatherDisplay(park.latitude, park.longitude)}
+        </div>
+        <div class="detailButton">
+          <button class="parkDetails" id="parkDetailButton--${
+            park.id
+          }">Details</button>
         </div>
       </div>
-      <div class="park-weather">
-        ${weatherDisplay(park.latitude, park.longitude)}
-      </div>
-      <div class="detailButton">
-        <button class="parkDetails" id="parkDetailButton--${
-          park.id
-        }">Details</button>
-      </div>
+      `;
+    return parkPreviewHTML;
+  } else {
+    parkPreviewHTML = `
+    <div class="preview-card preview-card--park">
+    <div class="preview-card--park__info">
+    <input type="hidden" id="selectedPark" value="${park.id}">
+    <div class="park-info__nameAndLocation">
+    <h4>
+    ${park.fullName}
+    </h4>
+    <p class="bold">Address Info Unavailable</p>
+    </div>
+    </div>
+    <div class="park-weather">
+    ${weatherDisplay(park.latitude, park.longitude)}
+    </div>
+    <div class="detailButton">
+    <button class="parkDetails" id="parkDetailButton--${
+      park.id
+    }">Details</button>
+    </div>
     </div>
     `;
-  return parkPreviewHTML;
+    return parkPreviewHTML;
+  }
 };

--- a/scripts/parks/ParkPreviewList.js
+++ b/scripts/parks/ParkPreviewList.js
@@ -20,6 +20,7 @@ eventHub.addEventListener('parkChosen', (event) => {
     } else {
       parkPreviewTarget.innerHTML = ParkPreviewHTMLgenerator(chosenPark);
     }
+
   } else parkPreviewTarget.innerHTML = '';
 });
 

--- a/scripts/search/SearchResult.js
+++ b/scripts/search/SearchResult.js
@@ -9,7 +9,7 @@ export const SearchResult = (result) => {
   let attractions = useAttractions();
   let eateries = useEateries();
 
-  if (result.type === 'park') {
+  if (result.type === 'park' && result.city) {
     let parkObject = parks.find((p) => p.id === result.id);
 
     return `
@@ -18,6 +18,21 @@ export const SearchResult = (result) => {
       <input type="hidden" id="selectedSearchResultId" value="${parkObject.id}">
           <h4>${parkObject.fullName}</h4>
           <p class="bold">${parkObject.addresses[0]?.city}, ${parkObject.addresses[0]?.stateCode}</p>
+      </section>
+      <div class="detailButton" >
+        <button id="addToPreviewButtonPark--${parkObject.id}" class="attractionDetails">Add to Preview</button>
+      </div>
+  </div>
+  `;
+  } else if (result.type === 'park' && !result.city) {
+    let parkObject = parks.find((p) => p.id === result.id);
+
+    return `
+    <div class="attractionContainer lightbg">
+      <section class="attraction">
+      <input type="hidden" id="selectedSearchResultId" value="${parkObject.id}">
+          <h4>${parkObject.fullName}</h4>
+          <p class="bold">Address Info Unavailable</p>
       </section>
       <div class="detailButton" >
         <button id="addToPreviewButtonPark--${parkObject.id}" class="attractionDetails">Add to Preview</button>


### PR DESCRIPTION
## changes
- added logic to handle parks that have an empty address array for both the preview cards and the search result cards
## testing
- fetch and serve
- choose one such park from the parks dropdown (i.e. Chesapeake Bay Gateways and Watertrails Network)
- observe that park preview address now says "Address Info Unavailable"
- search for the same park in the search bar
- observe that the search result card says "Address Info Unavailable"